### PR TITLE
Add stubbed C++ version

### DIFF
--- a/cpp_project/Makefile
+++ b/cpp_project/Makefile
@@ -1,0 +1,19 @@
+CXX=g++
+CXXFLAGS=-std=c++17 -Wall -Iinclude
+LDFLAGS=-lcurl
+SRC=$(wildcard src/*.cpp)
+OBJ=$(SRC:.cpp=.o)
+TARGET=trader
+
+all: $(TARGET)
+
+$(TARGET): $(OBJ)
+	$(CXX) $(OBJ) -o $@ $(LDFLAGS)
+
+%.o: %.cpp
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+clean:
+	rm -f src/*.o $(TARGET)
+
+.PHONY: all clean

--- a/cpp_project/include/AlpacaClient.hpp
+++ b/cpp_project/include/AlpacaClient.hpp
@@ -1,0 +1,32 @@
+#ifndef ALPACA_CLIENT_HPP
+#define ALPACA_CLIENT_HPP
+
+#include <string>
+#include <map>
+
+struct Position {
+    std::string symbol;
+    double qty{0};
+    double entry_price{0};
+};
+
+class AlpacaClient {
+public:
+    AlpacaClient(const std::string& apiKey,
+                 const std::string& apiSecret,
+                 const std::string& baseUrl);
+
+    double getAccountEquity();
+    bool isMarketOpen();
+    double getCurrentPrice(const std::string& symbol);
+    std::map<std::string, Position> listPositions();
+    void buy(const std::string& symbol, double dollars);
+    void sell(const std::string& symbol, double qty);
+
+private:
+    std::string key;
+    std::string secret;
+    std::string url;
+};
+
+#endif // ALPACA_CLIENT_HPP

--- a/cpp_project/include/MarketScanner.hpp
+++ b/cpp_project/include/MarketScanner.hpp
@@ -1,0 +1,13 @@
+#ifndef MARKET_SCANNER_HPP
+#define MARKET_SCANNER_HPP
+
+#include <string>
+#include <vector>
+
+class MarketScanner {
+public:
+    // Fetch top gainers from Yahoo finance.
+    std::vector<std::string> fetchTopGainers(int limit = 30);
+};
+
+#endif // MARKET_SCANNER_HPP

--- a/cpp_project/include/Trader.hpp
+++ b/cpp_project/include/Trader.hpp
@@ -1,0 +1,22 @@
+#ifndef TRADER_HPP
+#define TRADER_HPP
+
+#include "AlpacaClient.hpp"
+#include "MarketScanner.hpp"
+#include <string>
+#include <vector>
+
+class Trader {
+public:
+    Trader(const std::string& apiKey,
+           const std::string& apiSecret,
+           const std::string& baseUrl);
+
+    void run();
+
+private:
+    AlpacaClient api;
+    MarketScanner scanner;
+};
+
+#endif // TRADER_HPP

--- a/cpp_project/src/AlpacaClient.cpp
+++ b/cpp_project/src/AlpacaClient.cpp
@@ -1,0 +1,38 @@
+#include "AlpacaClient.hpp"
+#include <iostream>
+
+AlpacaClient::AlpacaClient(const std::string& apiKey,
+                           const std::string& apiSecret,
+                           const std::string& baseUrl)
+    : key(apiKey), secret(apiSecret), url(baseUrl) {}
+
+// Placeholder implementations
+
+double AlpacaClient::getAccountEquity() {
+    std::cout << "[Stub] getAccountEquity called" << std::endl;
+    return 0.0;
+}
+
+bool AlpacaClient::isMarketOpen() {
+    std::cout << "[Stub] isMarketOpen called" << std::endl;
+    return true;
+}
+
+double AlpacaClient::getCurrentPrice(const std::string& symbol) {
+    std::cout << "[Stub] getCurrentPrice(" << symbol << ")" << std::endl;
+    return 0.0;
+}
+
+std::map<std::string, Position> AlpacaClient::listPositions() {
+    std::cout << "[Stub] listPositions" << std::endl;
+    return {};
+}
+
+void AlpacaClient::buy(const std::string& symbol, double dollars) {
+    std::cout << "[Stub] buy " << symbol << " $" << dollars << std::endl;
+}
+
+void AlpacaClient::sell(const std::string& symbol, double qty) {
+    std::cout << "[Stub] sell " << symbol << " qty " << qty << std::endl;
+}
+

--- a/cpp_project/src/MarketScanner.cpp
+++ b/cpp_project/src/MarketScanner.cpp
@@ -1,0 +1,51 @@
+#include "MarketScanner.hpp"
+#include <curl/curl.h>
+#include <nlohmann/json.hpp>
+#include <iostream>
+
+using json = nlohmann::json;
+
+namespace {
+size_t WriteCallback(void* contents, size_t size, size_t nmemb, void* userp) {
+    ((std::string*)userp)->append((char*)contents, size * nmemb);
+    return size * nmemb;
+}
+}
+
+std::vector<std::string> MarketScanner::fetchTopGainers(int limit) {
+    std::vector<std::string> movers;
+    CURL* curl = curl_easy_init();
+    if (!curl) {
+        std::cerr << "Failed to init curl" << std::endl;
+        return movers;
+    }
+
+    std::string readBuffer;
+    std::string url = "https://query1.finance.yahoo.com/v7/finance/screener/predefined/saved?";
+    url += "scrIds=day_gainers&count=" + std::to_string(limit);
+
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
+    CURLcode res = curl_easy_perform(curl);
+    if (res != CURLE_OK) {
+        std::cerr << "curl_easy_perform() failed: " << curl_easy_strerror(res) << std::endl;
+        curl_easy_cleanup(curl);
+        return movers;
+    }
+    curl_easy_cleanup(curl);
+
+    try {
+        auto j = json::parse(readBuffer);
+        auto quotes = j["finance"]["result"][0]["quotes"];
+        for (auto& q : quotes) {
+            if (q.contains("symbol") && q.contains("regularMarketPrice") && q["regularMarketPrice"].get<double>() > 5) {
+                movers.push_back(q["symbol"].get<std::string>());
+            }
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "JSON parse error: " << e.what() << std::endl;
+    }
+    return movers;
+}
+

--- a/cpp_project/src/Trader.cpp
+++ b/cpp_project/src/Trader.cpp
@@ -1,0 +1,18 @@
+#include "Trader.hpp"
+#include <iostream>
+
+Trader::Trader(const std::string& apiKey,
+               const std::string& apiSecret,
+               const std::string& baseUrl)
+    : api(apiKey, apiSecret, baseUrl) {}
+
+void Trader::run() {
+    std::cout << "Fetching top gainers..." << std::endl;
+    auto gainers = scanner.fetchTopGainers();
+    std::cout << "Found " << gainers.size() << " gainers" << std::endl;
+    for (const auto& g : gainers) {
+        std::cout << " - " << g << std::endl;
+    }
+    // Placeholder for trading logic
+}
+

--- a/cpp_project/src/main.cpp
+++ b/cpp_project/src/main.cpp
@@ -1,0 +1,13 @@
+#include "Trader.hpp"
+#include <cstdlib>
+
+int main() {
+    const char* key = std::getenv("ALPACA_API_KEY");
+    const char* secret = std::getenv("ALPACA_API_SECRET");
+    const char* url = std::getenv("ALPACA_BASE_URL");
+
+    Trader trader(key ? key : "", secret ? secret : "", url ? url : "");
+    trader.run();
+    return 0;
+}
+

--- a/readme.md
+++ b/readme.md
@@ -118,3 +118,18 @@ Open an issue or [contact me here](mailto:your@email.com)!
 ---
 
 **Happy trading!**
+
+---
+
+## C++ Version
+
+A simplified C++ implementation is provided in `cpp_project/`. It demonstrates an object-oriented approach with stubbed API calls and a `Makefile` for building:
+
+```bash
+cd cpp_project
+make
+./trader
+```
+
+The C++ code fetches real-time gainers from Yahoo Finance using libcurl and prints them. Actual trading logic would need to be implemented to interact with the Alpaca API.
+


### PR DESCRIPTION
## Summary
- add a new `cpp_project` with an object‑oriented C++ trading stub
- provide Makefile for easy compilation
- document the C++ version in `readme.md`

## Testing
- `make -C cpp_project`
- `./trader` (shows error due to network restrictions)


------
https://chatgpt.com/codex/tasks/task_e_686d2b20b57883258717f4e36cd90a08