### PR TITLE
Add async trading bot prototype

### DIFF
--- a/v2/api.py
+++ b/v2/api.py
@@ -1,0 +1,60 @@
+import aiohttp
+from typing import List
+from .logger import logger
+from .config import NEWS_API_KEY
+
+YAHOO_GAINERS_URL = "https://query1.finance.yahoo.com/v7/finance/screener/predefined/saved"
+NEWS_URL = "https://newsapi.org/v2/everything"
+
+class MarketAPI:
+    def __init__(self):
+        self.session = aiohttp.ClientSession()
+
+    async def close(self):
+        await self.session.close()
+
+    async def get_top_movers(self, limit: int = 10) -> List[str]:
+        params = {"scrIds": "day_gainers", "count": limit}
+        try:
+            async with self.session.get(YAHOO_GAINERS_URL, params=params, timeout=10) as resp:
+                data = await resp.json()
+                quotes = data['finance']['result'][0]['quotes']
+                movers = [q['symbol'] for q in quotes if q.get('regularMarketPrice', 0) > 5]
+                logger.info(f"Fetched top movers: {movers}")
+                return movers
+        except Exception as e:
+            logger.error(f"Error fetching top movers: {e}")
+            return []
+
+    async def fetch_news(self, symbol: str, limit: int = 5) -> List[str]:
+        if not NEWS_API_KEY:
+            logger.warning("NEWS_API_KEY not set, skipping news fetch")
+            return []
+        params = {
+            "q": symbol,
+            "apiKey": NEWS_API_KEY,
+            "pageSize": limit,
+            "sortBy": "publishedAt",
+            "language": "en"
+        }
+        try:
+            async with self.session.get(NEWS_URL, params=params, timeout=10) as resp:
+                data = await resp.json()
+                titles = [article['title'] for article in data.get('articles', [])]
+                logger.info(f"News for {symbol}: {titles}")
+                return titles
+        except Exception as e:
+            logger.error(f"Error fetching news for {symbol}: {e}")
+            return []
+
+    async def fetch_price_history(self, symbol: str, range: str = '1d', interval: str = '5m') -> List[float]:
+        url = f'https://query1.finance.yahoo.com/v8/finance/chart/{symbol}'
+        params = {"range": range, "interval": interval}
+        try:
+            async with self.session.get(url, params=params, timeout=10) as resp:
+                data = await resp.json()
+                closes = data['chart']['result'][0]['indicators']['quote'][0]['close']
+                return [c for c in closes if c is not None]
+        except Exception as e:
+            logger.error(f"Error fetching price data for {symbol}: {e}")
+            return []

--- a/v2/config.py
+++ b/v2/config.py
@@ -1,0 +1,12 @@
+import os
+
+ALPACA_API_KEY = os.getenv('ALPACA_API_KEY')
+ALPACA_API_SECRET = os.getenv('ALPACA_API_SECRET')
+ALPACA_BASE_URL = os.getenv('ALPACA_BASE_URL', 'https://paper-api.alpaca.markets')
+NEWS_API_KEY = os.getenv('NEWS_API_KEY')
+
+STARTING_CASH = float(os.getenv('STARTING_CASH', 100))
+POSITIONS = int(os.getenv('POSITIONS', 5))
+
+# Logging configuration
+LOG_LEVEL = os.getenv('LOG_LEVEL', 'INFO')

--- a/v2/logger.py
+++ b/v2/logger.py
@@ -1,0 +1,9 @@
+import logging
+from .config import LOG_LEVEL
+
+logger = logging.getLogger('trading_bot')
+handler = logging.StreamHandler()
+formatter = logging.Formatter('[%(asctime)s] %(levelname)s - %(message)s')
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+logger.setLevel(LOG_LEVEL)

--- a/v2/main.py
+++ b/v2/main.py
@@ -1,0 +1,9 @@
+import asyncio
+from .trader import Trader
+
+async def main():
+    trader = Trader()
+    await trader.run()
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/v2/model.py
+++ b/v2/model.py
@@ -1,0 +1,16 @@
+import numpy as np
+from typing import List
+
+class PricePredictor:
+    """Simple linear regression predictor."""
+
+    def predict_next(self, prices: List[float]) -> float:
+        if len(prices) < 2:
+            return prices[-1] if prices else 0
+        x = np.arange(len(prices))
+        y = np.array(prices)
+        A = np.vstack([x, np.ones(len(x))]).T
+        m, b = np.linalg.lstsq(A, y, rcond=None)[0]
+        next_x = len(prices)
+        prediction = m * next_x + b
+        return float(prediction)

--- a/v2/requirements.txt
+++ b/v2/requirements.txt
@@ -1,0 +1,2 @@
+aiohttp
+numpy

--- a/v2/trader.py
+++ b/v2/trader.py
@@ -1,0 +1,44 @@
+import asyncio
+from typing import List, Dict
+
+from .api import MarketAPI
+from .model import PricePredictor
+from .logger import logger
+from .config import POSITIONS
+
+class Trader:
+    def __init__(self):
+        self.api = MarketAPI()
+        self.predictor = PricePredictor()
+
+    async def analyze_symbol(self, symbol: str) -> Dict:
+        prices, news = await asyncio.gather(
+            self.api.fetch_price_history(symbol),
+            self.api.fetch_news(symbol)
+        )
+        if not prices:
+            return {"symbol": symbol, "score": -float('inf')}
+        prediction = self.predictor.predict_next(prices)
+        current = prices[-1]
+        score = prediction - current
+        logger.info(f"{symbol} prediction: {prediction:.2f}, current: {current:.2f}, score: {score:.2f}")
+        return {"symbol": symbol, "score": score, "news": news, "prediction": prediction}
+
+    async def pick_winners(self, candidates: List[str]) -> List[Dict]:
+        tasks = [self.analyze_symbol(sym) for sym in candidates]
+        results = await asyncio.gather(*tasks)
+        results.sort(key=lambda x: x['score'], reverse=True)
+        return results[:POSITIONS]
+
+    async def run(self):
+        movers = await self.api.get_top_movers(limit=POSITIONS * 5)
+        if not movers:
+            logger.error("No movers found.")
+            return
+        winners = await self.pick_winners(movers)
+        for win in winners:
+            logger.info(f"Top pick {win['symbol']} predicted {win['prediction']:.2f}")
+            for headline in win.get('news', []):
+                logger.info(f" - {headline}")
+        await self.api.close()
+


### PR DESCRIPTION
## Summary
- create v2 folder with async OOP trading framework
- implement MarketAPI for async calls to Yahoo Finance and NewsAPI
- add simple linear regression price predictor
- build Trader class to pick winners using async concurrency
- provide entry point with logging configuration

## Testing
- `python -m py_compile v2/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686d2cfcb974832598a8a52aafab0f54